### PR TITLE
adding a bash script for easier ssh commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,6 @@ RUN echo "Creating base ubuntu image" && \
     apt install -y vim sudo curl openssh-server
 COPY start /usr/bin/start
 RUN chmod +x /usr/bin/start
-CMD [ "start" ]
+COPY access /usr/bin/access
+RUN chmod +x /usr/bin/access
+CMD [ "start"] [ "access" ]

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ After cloning this repository to your local machine, you will need to:
 - Launch terminal (mac)
 - Navigate to the directory, where you cloned this repository
 - Execute the following command in the terminal: `make build-n-run`
+- Once you are in the container, you can run the following command to ssh: `access ${user} ${host_name}`
 
 ## Commands ##
 - `make build` will build the base image

--- a/access
+++ b/access
@@ -1,0 +1,6 @@
+#! /bin/bash
+
+user=$1
+host=$2
+
+ssh -o StrictHostKeyChecking=no $user@$host


### PR DESCRIPTION
Adding a bash script named "access" and adding no strict host key checking to the script. You will not run into issues around host key checking if you are working with multiple machines.